### PR TITLE
Get, post, and delete event and shelter bookmarks

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -34,3 +34,15 @@ export enum UserRole {
   USER = 'USER',
   ADMIN = 'ADMIN',
 }
+
+/**
+ * Interface extending the request body when logging in an existing user, which contains:
+ * - userId - The ID of the user.
+ * - bookmarkId - The ID of the bookmark.
+ */
+export interface BookmarkRequest extends Request {
+  body: {
+    userId: string;
+    bookmarkId: string;
+  };
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -5,10 +5,13 @@ import {
   Post,
   Body,
   Get,
+  Query,
+  Param,
+  Delete,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { NewUserInput } from '../dtos/newUserDTO';
-import { LoginUserRequest } from '../types';
+import { BookmarkRequest, LoginUserRequest } from '../types';
 import { UserModel } from './user.model';
 
 @Controller('users')
@@ -55,5 +58,27 @@ export class UserController {
         HttpStatus.BAD_REQUEST
       );
     }
+  }
+
+  @Get('/bookmarks/:userId')
+  public async getUserBookmarks(
+    @Param('userId') userId: string,
+    @Query('type') type: 'shelter' | 'event'
+  ) {
+    return await this.userService.getUserBookmarks(userId, type);
+  }
+
+  @Post('/bookmarks/:type')
+  public async postUserBookmark(
+    @Param('type') type: 'shelter' | 'event',
+    @Body() bookmarkData: BookmarkRequest
+  ) {
+    const { userId, bookmarkId } = bookmarkData.body;
+
+    return await this.userService.postOrDeleteBookmark(
+      userId,
+      bookmarkId,
+      type
+    );
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -75,10 +75,16 @@ export class UserController {
   ) {
     const { userId, bookmarkId } = bookmarkData.body;
 
-    return await this.userService.postOrDeleteBookmark(
-      userId,
-      bookmarkId,
-      type
-    );
+    return await this.userService.postBookmark(userId, bookmarkId, type);
+  }
+
+  @Delete('/bookmarks/:type')
+  public async deleteUserBookmark(
+    @Param('type') type: 'shelter' | 'event',
+    @Body() bookmarkData: BookmarkRequest
+  ) {
+    const { userId, bookmarkId } = bookmarkData.body;
+
+    return await this.userService.deleteBookmark(userId, bookmarkId, type);
   }
 }

--- a/backend/src/user/userBookmarks.model.ts
+++ b/backend/src/user/userBookmarks.model.ts
@@ -1,0 +1,35 @@
+/**
+ * Represents the schema of a user's shelter bookmarks
+ */
+export type UserShelterBookmarkModel = {
+  userId: string;
+  shelterId: string;
+  created_at: string;
+};
+
+/**
+ * Represents the schema of a user's shelter bookmarks suitable for DynamoDB.
+ */
+export type UserShelterBookmarkInputModel = {
+  userId: { S: string };
+  shelterId: { S: string };
+  created_at: { S: string };
+};
+
+/**
+ * Represents the schema of a user's event bookmarks
+ */
+export type UserEventBookmarkModel = {
+  userId: string;
+  eventId: string;
+  created_at: string;
+};
+
+/**
+ * Represents the schema of a user's event bookmarks suitable for DynamoDB.
+ */
+export type UserEventBookmarkInputModel = {
+  userId: { S: string };
+  eventId: { S: string };
+  created_at: { S: string };
+};


### PR DESCRIPTION
Enables retrieving, posting, and deleting bookmarks for shelters and events. If post is called and the bookmark already exists, it will be deleted.

<img width="851" alt="image" src="https://github.com/user-attachments/assets/712ff369-1112-4784-ac57-43fdbdd08c4c" />
<img width="843" alt="image" src="https://github.com/user-attachments/assets/bc505943-ae16-4d1d-a480-3865fcf94db1" />


<img width="847" alt="image" src="https://github.com/user-attachments/assets/8cea63d6-8f9b-49b1-81d4-1d3b220f23ad" />
<img width="834" alt="image" src="https://github.com/user-attachments/assets/92a07d8d-6db8-4eb3-9f6c-7b576b17b166" />


<img width="853" alt="image" src="https://github.com/user-attachments/assets/4e7f3ef7-5c25-40b1-b0b9-e6f49edf4ef8" />
<img width="855" alt="image" src="https://github.com/user-attachments/assets/6f834183-f5b1-4249-bda5-1fc51cdf4886" />
